### PR TITLE
Suppressed Beautifulsoup warning

### DIFF
--- a/scripts/nbsite_fix_links.py
+++ b/scripts/nbsite_fix_links.py
@@ -90,7 +90,7 @@ def cleanup_links(path):
 #            text = text.replace(k, v)
 
     text = component_links(text, path)
-    soup = BeautifulSoup(text)
+    soup = BeautifulSoup(text, "lxml")
     for a in soup.findAll('a'):
         href = a.get('href', '')
         if '.ipynb' in href and 'http' not in href:


### PR DESCRIPTION
This change seems to get rid of this warning:

```
anaconda/envs/ds/lib/python3.6/site-packages/bs4/__init__.py:181: 
UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser
for this system ("lxml"). This usually isn't a problem, but if you run this code on another system,
or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 121 of the file 
anaconda/envs/ds/bin/nbsite_fix_links.py. 
To get rid of this warning, change code that looks like this:

 BeautifulSoup(YOUR_MARKUP})

to this:

 BeautifulSoup(YOUR_MARKUP, "lxml")

  markup_type=markup_type))
```