### PR TITLE
Require alpha tags to have one more more digits for the alpha 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,15 @@ env:
 stages:
   - test
   - name: conda_dev_package
-    if: tag =~ ^v(\d+|\.)*[a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: pip_dev_package
-    if: tag =~ ^v(\d+|\.)*[a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: conda_package
-    if: tag =~ ^v(\d+|\.)*[^a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: pip_package
-    if: tag =~ ^v(\d+|\.)*[^a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: docs
-    if: tag =~ ^v(\d+|\.).*$
+    if: tag =~ ^v(\d+|\.)+.*\d+$
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
           on:
             tags: true
             all_branches: true
-            condition: $TRAVIS_TAG =~ [0-9]+[a-z][0-9]*$
+            condition: $TRAVIS_TAG =~ [0-9]+[a-z][0-9]+$
         - provider: pages
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
@@ -72,7 +72,7 @@ jobs:
           on:
             tags: true
             all_branches: true
-            condition: $TRAVIS_TAG =~ [0-9]+[^a-z][0-9]*$
+            condition: $TRAVIS_TAG =~ [0-9]+[^a-z][0-9]+$
 
 
     ########## END-USER PACKAGES ##########


### PR DESCRIPTION
(e.g. v0.1.2a0, not v0.1.2a)

This change should prevent e.g. v0.1.2a10 from being matched as 'release'. 

(It's difficult to write a regex in the travis file because the flavor being used is unclear, and seems to vary depending where you are in the file...)