### PR TITLE
Moving evaluated notebooks to doc dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@
 *.out
 *.lock
 *.doit*
+
+# nbsite
+# these files normally shouldn't be checked in as they should be
+# dynamically built from notebooks
+doc/**/*.rst
+doc/**/*.ipynb
+doc/**/*.json
+# this dir contains the whole website and should not be checked in on master
+builtdocs/

--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -41,7 +41,7 @@ def main(args=None):
     build_parser.add_argument('--output',type=str,help='where to init doc',default="builtdocs")
     _add_common_args(build_parser,'--project-root','--doc','--examples')
     build_parser.add_argument('--examples-assets',type=str,help='where to init doc',default="assets")
-    build_parser.add_argument('--clean-force',action='store_true',help='whether to actually delete files when cleaning (useful for uploading)')
+    build_parser.add_argument('--clean-dry-run',action='store_true',help='whether to not actually delete files from output (useful for uploading)')
     _set_defaults(build_parser,build)
 
     # add commands from pyct, for examples

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -29,7 +29,7 @@ def fix_links(output):
     subprocess.check_call(["nbsite_fix_links.py",output])
 
 
-def build(what,output,project_root='',doc='doc',examples='examples',examples_assets="assets", clean_force=False):
+def build(what,output,project_root='',doc='doc',examples='examples',examples_assets="assets", clean_dry_run=False):
     # TODO: also have an overwrite flag
     paths = _prepare_paths(project_root,examples=examples,doc=doc,examples_assets=examples_assets)
     subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output])
@@ -40,11 +40,11 @@ def build(what,output,project_root='',doc='doc',examples='examples',examples_ass
     fix_links(output)
     # create a .nojekyll file in output for github compatibility
     subprocess.check_call(["touch", os.path.join(output, '.nojekyll')])
-    if not clean_force:
-        print("Call `nbsite build` with `--clean-force` to actually delete files.")
-    clean(output, not clean_force)
+    if not clean_dry_run:
+        print("Call `nbsite build` with `--clean-dry-run` to not actually delete files.")
+    clean(output, clean_dry_run)
 
-def clean(output, dry_run=True):
+def clean(output, dry_run=False):
     if dry_run:
         subprocess.check_call(["nbsite_cleandisthtml.py",output])
     else:

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -159,8 +159,7 @@ class NotebookDirective(Directive):
         nb_abs_path = os.path.abspath(os.path.join(rst_dir, self.arguments[1]))
         nb_filepath, nb_basename = os.path.split(nb_abs_path)
 
-        rel_dir = os.path.relpath(rst_dir, setup.confdir)
-        dest_dir = rst_dir #os.path.join(setup.app.builder.outdir, rel_dir)
+        dest_dir = rst_dir
         dest_path = os.path.join(dest_dir, nb_basename)
 
         if not os.path.exists(dest_dir):
@@ -169,7 +168,6 @@ class NotebookDirective(Directive):
         # Process file inclusion options
         include_opts = self.arguments[2:]
         include_nb = True if 'ipynb' in include_opts else False
-        include_eval = True if 'eval' in include_opts else False
         include_script = True if 'py' in include_opts else False
 
         link_rst = ''

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -269,7 +269,7 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=N
 
     if not os.path.isfile(dest_path):
         # TODO but this isn't true, is it? it's running the originl nb
-        print('INFO: Writing evalutated notebook to {dest_path!s}'.format(
+        print('INFO: Writing evaluated notebook to {dest_path!s}'.format(
             dest_path=os.path.abspath(dest_path)))
         try:
             if not skip_execute:

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -48,7 +48,7 @@ class ExecutePreprocessor1000(ExecutePreprocessor):
     @kc.deleter
     def kc(self):
         del self._kc
-    
+
     @kc.setter
     def kc(self,v):
         self._kc=v
@@ -160,7 +160,7 @@ class NotebookDirective(Directive):
         nb_filepath, nb_basename = os.path.split(nb_abs_path)
 
         rel_dir = os.path.relpath(rst_dir, setup.confdir)
-        dest_dir = os.path.join(setup.app.builder.outdir, rel_dir)
+        dest_dir = rst_dir #os.path.join(setup.app.builder.outdir, rel_dir)
         dest_path = os.path.join(dest_dir, nb_basename)
 
         if not os.path.exists(dest_dir):
@@ -179,13 +179,6 @@ class NotebookDirective(Directive):
         if include_nb:
             link_rst += formatted_link(nb_basename) + '; '
 
-        if include_eval:
-            dest_path_eval = string.replace(dest_path, '.ipynb', '_evaluated.ipynb')
-            rel_path_eval = string.replace(nb_basename, '.ipynb', '_evaluated.ipynb')
-            link_rst += formatted_link(rel_path_eval) + ('; ' if include_script else '')
-        else:
-            dest_path_eval = os.path.join(dest_dir, 'temp_evaluated.ipynb')
-
         if include_script:
             dest_path_script = string.replace(dest_path, '.ipynb', '.py')
             rel_path_script = string.replace(nb_basename, '.ipynb', '.py')
@@ -202,13 +195,8 @@ class NotebookDirective(Directive):
         # Evaluate Notebook and insert into Sphinx doc
         skip_exceptions = 'skip_exceptions' in self.options
 
-        # Make temp_evaluated.ipynb include the notebook name
-        nb_name = os.path.split(nb_abs_path)[1].replace('.ipynb','')
-        dest_path_eval = dest_path_eval.replace('temp_evaluated.ipynb',
-                               '{nb_name}_temp_evaluated.ipynb'.format(nb_name=nb_name))
-
         # Parse slice
-        evaluated_text = evaluate_notebook(nb_abs_path, dest_path_eval,
+        evaluated_text = evaluate_notebook(nb_abs_path, dest_path,
                                            skip_exceptions=skip_exceptions,
                                            substring=self.options.get('substring'),
                                            end=self.options.get('end'),
@@ -283,7 +271,7 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=N
 
     if not os.path.isfile(dest_path):
         # TODO but this isn't true, is it? it's running the originl nb
-        print('INFO: Running temp notebook {dest_path!s}'.format(
+        print('INFO: Writing evalutated notebook to {dest_path!s}'.format(
             dest_path=os.path.abspath(dest_path)))
         try:
             if not skip_execute:
@@ -308,9 +296,8 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=N
                 for f in glob.glob(os.path.join(os.path.dirname(nb_path),pattern)):
                     print("mv %s %s"%(f, os.path.dirname(dest_path)))
                     shutil.move(f,os.path.dirname(dest_path))
-            
     else:
-        print('INFO: Skipping existing temp notebook {dest_path!s}'.format(
+        print('INFO: Skipping existing evaluated notebook {dest_path!s}'.format(
             dest_path=os.path.abspath(dest_path)))
 
     preprocessors = [] if substring is None and not offset else [NotebookSlice(substring, end, offset)]
@@ -339,7 +326,7 @@ def setup(app):
     app.add_config_value('nbbuild_cell_timeout',300,'html')
     app.add_config_value('nbbuild_ipython_startup',"from nbsite.ipystartup import *",'html')
     app.add_config_value('nbbuild_patterns_to_take_along',["*.json"],'html')
-    
+
     app.add_node(notebook_node,
                  html=(visit_notebook_node, depart_notebook_node))
 

--- a/nbsite/tests/test_cmd.py
+++ b/nbsite/tests/test_cmd.py
@@ -312,21 +312,21 @@ def test_build_with_just_one_rst(tmp_project_with_docs_skeleton):
     assert (project / "builtdocs" / ".nojekyll").is_file()
 
 @pytest.mark.slow
-def test_build_does_not_deletes_by_default(tmp_project_with_docs_skeleton):
+def test_build_deletes_by_default(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
     (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
     (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
-    assert (project / "builtdocs" / ".doctrees").is_dir()
-    assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
-    assert len(list((project / "builtdocs").iterdir())) == 12
-
-@pytest.mark.slow
-def test_build_with_clean_force_deletes(tmp_project_with_docs_skeleton):
-    project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
-    (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
-    build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='', clean_force=True)
     assert not (project / "builtdocs" / ".doctrees").is_dir()
     assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
     assert len(list((project / "builtdocs").iterdir())) == 9
+
+@pytest.mark.slow
+def test_build_with_clean_dry_run_does_not_delere(tmp_project_with_docs_skeleton):
+    project = tmp_project_with_docs_skeleton
+    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
+    build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='', clean_dry_run=True)
+    assert (project / "builtdocs" / ".doctrees").is_dir()
+    assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
+    assert len(list((project / "builtdocs").iterdir())) == 12

--- a/nbsite/tests/test_cmd.py
+++ b/nbsite/tests/test_cmd.py
@@ -284,6 +284,8 @@ def test_build(tmp_project_with_docs_skeleton):
     (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
     (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
+    assert (project / "doc" / "Example_Notebook_0.ipynb").is_file()
+    assert (project / "doc" / "Example_Notebook_1.ipynb").is_file()
     assert (project / "builtdocs" / "Example_Notebook_0.html").is_file()
     assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
 
@@ -315,9 +317,9 @@ def test_build_does_not_deletes_by_default(tmp_project_with_docs_skeleton):
     (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
     (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
-    assert (project / "builtdocs" / "Example_Notebook_1_temp_evaluated.ipynb").is_file()
+    assert (project / "builtdocs" / ".doctrees").is_dir()
     assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
-    assert len(list((project / "builtdocs").iterdir())) == 14
+    assert len(list((project / "builtdocs").iterdir())) == 12
 
 @pytest.mark.slow
 def test_build_with_clean_force_deletes(tmp_project_with_docs_skeleton):
@@ -325,6 +327,6 @@ def test_build_with_clean_force_deletes(tmp_project_with_docs_skeleton):
     (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
     (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='', clean_force=True)
-    assert not (project / "builtdocs" / "Example_Notebook_1_temp_evaluated.ipynb").is_file()
+    assert not (project / "builtdocs" / ".doctrees").is_dir()
     assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
     assert len(list((project / "builtdocs").iterdir())) == 9


### PR DESCRIPTION
This PR would move the evaluated notebooks to the doc dir with no extra suffix. It also sets up a pattern for git-ignoring the .rst, .json, and .ipynb contents of doc as well as builtdoc so they don't get checked in accidentally.

The idea is that this would make it so that you could have the evaluated notebooks locally, and if you want to re-run a particular one you can just delete the evaluated notebook, delete the html and run `nbsite build` again:

```
(pyviz) ➜  pyviz git:(master) ✗ rm builtdocs/topics/nyc_taxi.html
(pyviz) ➜  pyviz git:(master) ✗ rm doc/topics/nyc_taxi.ipynb
(pyviz) ➜  pyviz git:(master) ✗ nbsite build --what=html --output=builtdocs --clean-force
Running Sphinx v1.8.1
/Users/jsignell/conda/envs/pyviz/lib/python3.6/site-packages/IPython/nbconvert.py:13: ShimWarning: The `IPython.nbconvert` package has been deprecated since IPython 4.0. You should import from nbconvert instead.
  "You should import from nbconvert instead.", ShimWarning)
/Users/jsignell/conda/envs/pyviz/lib/python3.6/site-packages/IPython/nbformat.py:13: ShimWarning: The `IPython.nbformat` package has been deprecated since IPython 4.0. You should import from nbformat instead.
  "You should import from nbformat instead.", ShimWarning)
/Users/jsignell/conda/envs/pyviz/lib/python3.6/site-packages/nbformat/current.py:19: UserWarning: nbformat.current is deprecated.

- use nbformat for read/write/validate public API
- use nbformat.vX directly to composing notebooks of a particular version

  """)
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 28 source files that are out of date
updating environment: 28 added, 0 changed, 0 removed
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/topics/index.ipynb
INFO: Writing evalutated notebook to /Users/jsignell/websites/pyviz/doc/topics/nyc_taxi.ipynb
INFO:traitlets:Executing notebook with kernel: python3
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/00_Setup.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/01_Workflow_Introduction.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/02_Annotating_Data.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/03_Customizing_Visual_Appearance.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/04_Working_with_Tabular_Data.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/05_Working_with_Gridded_Data.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/06_Network_Graphs.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/07_Geographic_Data.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/08_Custom_Interactivity.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/09_Operations_and_Pipelines.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/10_Working_with_Large_Datasets.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/11_Streaming_Data.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/12_Parameters_and_Widgets.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/13_Deploying_Bokeh_Apps.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/A1_Exploration_with_Containers.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/A2_Dashboard_Workflow.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/index.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/scipy18.ipynb
INFO: Skipping existing evaluated notebook /Users/jsignell/websites/pyviz/doc/tutorial/strata_ny18.ipynb

/Users/jsignell/websites/pyviz/doc/Roadmap.rst:189: WARNING: Enumerated list ends without a blank line; unexpected unindent.
/Users/jsignell/websites/pyviz/doc/background.rst:: WARNING: image file not readable: assets/ds_hv_bokeh.png
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/jsignell/websites/pyviz/doc/tutorial/scipy18.rst: WARNING: document isn't included in any toctree
/Users/jsignell/websites/pyviz/doc/tutorial/strata_ny18.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] tutorial/strata_ny18
generating indices... genindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 4 warnings.

The HTML pages are in ../../builtdocs.
Copying examples assets from /Users/jsignell/websites/pyviz/examples/assets to builtdocs/assets
/Users/jsignell/websites/nbsite/scripts/nbsite_fix_links.py:93: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 93 of the file /Users/jsignell/websites/nbsite/scripts/nbsite_fix_links.py. To get rid of this warning, pass the additional argument 'features="lxml"' to the BeautifulSoup constructor.

  soup = BeautifulSoup(text)
Removing files from: /Users/jsignell/websites/pyviz/builtdocs
removing .doctrees
removing _sources
removing objects.inv
```

Some notes:
 - with these changes we can probably drop the `--clean-force` flag and just always clean out the _sources, .doctrees...
 - we should think about adding convenience functions to delete/overwrite all the generated rsts, evaluated notebooks, and html
 - I think the nbbuild script has a lot of inaccessible option at the moment so it could stand for some cleaning.