### PR TITLE
Making setup.py safer by allowing for param not to exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,38 @@ import glob
 from setuptools import setup, find_packages
 
 import pyct.build
-import param
 
 NAME = 'nbsite'
 DESCRIPTION = 'Build a tested, sphinx-based website from notebooks.'
 
+# duplicated from pyct.build.get_setup_version until pyct[build] >0.4.6 lands
+def get_setup_version(root, reponame):
+    """
+    Helper to get the current version from either git describe or the
+    .version file (if available) - allows for param to not be available.
+    Normally used in setup.py as follows:
+    >>> from pyct.build import get_setup_version
+    >>> version = get_setup_version(__file__, reponame)  # noqa
+    """
+    import os
+    import json
+
+    filepath = os.path.abspath(os.path.dirname(root))
+    version_file_path = os.path.join(filepath, reponame, '.version')
+    try:
+        from param import version
+    except:
+        version = None
+    if version is not None:
+        return version.Version.setup_version(filepath, reponame, archive_commit="$Format:%h$")
+    else:
+        print("WARNING: param>=1.6.0 unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should install param>=1.6.0.")
+        return json.load(open(version_file_path, 'r'))['version_string']
+
 setup_args = dict(
     name=NAME,
     # version=pyct.build.get_setup_version(__file__, NAME),
-    version=param.version.get_setup_version(__file__, NAME),
+    version=get_setup_version(__file__, NAME),
     description=DESCRIPTION,
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This will be undone once pyct>0.4.6 lands, but for now it is safer