### PR TITLE
Adding `--strip-numbers` flag to generate_rst

### DIFF
--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -34,7 +34,7 @@ def main(args=None):
     generaterst_parser.add_argument('--offset',type=int,help='number of cells to delete from top of notebooks',default=0)
     generaterst_parser.add_argument('--nblink',type=str,help='where to place notebook links',choices=['bottom', 'top', 'both', 'none'], default='bottom')
     generaterst_parser.add_argument('--skip',type=str,help='notebooks to skip running; comma separated case insensitive re to match',default='')
-    generaterst_parser.add_argument('--strip-numbers',action='store_true',help='whether to strip the leading numbers off of notebook URLs and titles')
+    generaterst_parser.add_argument('--keep-numbers',action='store_true',help='whether to keep the leading numbers of notebook URLs and titles')
     _set_defaults(generaterst_parser,generate_rst)
 
     build_parser = subparsers.add_parser("build", help=inspect.getdoc(build))

--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -8,6 +8,7 @@ def _add_common_args(parser,*names):
         '--project-root': dict(type=str,help='defaults to current working directory',default=''),
         '--examples': dict(type=str,help='if relative, should be relative to project-root',default='examples'),
         '--doc': dict(type=str,help='if relative, should be releative to project-root',default='doc')
+        '--overwrite' dict(action='store_true', help='whether to overwrite any files [DANGEROUS]')
         }
     for name in names:
         parser.add_argument(name,**common[name])
@@ -24,14 +25,13 @@ def main(args=None):
     _set_defaults(init_parser,init)
 
     generaterst_parser = subparsers.add_parser("generate-rst", help=inspect.getdoc(generate_rst))
-    _add_common_args(generaterst_parser,'--project-root','--doc','--examples')
+    _add_common_args(generaterst_parser,'--project-root','--doc','--examples', '--overwrite')
     generaterst_parser.add_argument('--project-name', type=str, help='name of project')
     generaterst_parser.add_argument('--host',type=str,help='host to use when generating notebook links',default='GitHub')
     generaterst_parser.add_argument('--org',type=str,help='github organization',default='')
     generaterst_parser.add_argument('--repo',type=str,help='name of repo',default='')
     generaterst_parser.add_argument('--branch',type=str,help='branch to point to in notebook links',default='master')
     generaterst_parser.add_argument('--offset',type=int,help='number of cells to delete from top of notebooks',default=0)
-    generaterst_parser.add_argument('--overwrite',action='store_true', help='whether to overwrite any pre-existing rst [DANGEROUS]')
     generaterst_parser.add_argument('--nblink',type=str,help='where to place notebook links',choices=['bottom', 'top', 'both', 'none'], default='bottom')
     generaterst_parser.add_argument('--skip',type=str,help='notebooks to skip running; comma separated case insensitive re to match',default='')
     _set_defaults(generaterst_parser,generate_rst)
@@ -39,12 +39,11 @@ def main(args=None):
     build_parser = subparsers.add_parser("build", help=inspect.getdoc(build))
     build_parser.add_argument('--what',type=str,help='type of output to generate',default='html')
     build_parser.add_argument('--output',type=str,help='where to place output',default="builtdocs")
-    _add_common_args(build_parser,'--project-root','--doc','--examples')
+    _add_common_args(build_parser,'--project-root','--doc','--examples', '--overwrite')
     build_parser.add_argument('--examples-assets',type=str,default="assets",
                               help='dir in which assets for examples are located - if relative, should be releative to project-root')
     build_parser.add_argument('--clean-dry-run',action='store_true',help='whether to not actually delete files from output (useful for uploading)')
     build_parser.add_argument('--inspect-links',action='store_true',help='whether to not to print all links')
-    build_parser.add_argument('--overwrite',action='store_true', help='whether to overwrite any pre-existing evaluated notebooks [DANGEROUS]')
     _set_defaults(build_parser,build)
 
     # add commands from pyct, for examples

--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -7,8 +7,8 @@ def _add_common_args(parser,*names):
     common = {
         '--project-root': dict(type=str,help='defaults to current working directory',default=''),
         '--examples': dict(type=str,help='if relative, should be relative to project-root',default='examples'),
-        '--doc': dict(type=str,help='if relative, should be releative to project-root',default='doc')
-        '--overwrite' dict(action='store_true', help='whether to overwrite any files [DANGEROUS]')
+        '--doc': dict(type=str,help='if relative, should be releative to project-root',default='doc'),
+        '--overwrite': dict(action='store_true', help='whether to overwrite any files [DANGEROUS]')
         }
     for name in names:
         parser.add_argument(name,**common[name])
@@ -34,6 +34,7 @@ def main(args=None):
     generaterst_parser.add_argument('--offset',type=int,help='number of cells to delete from top of notebooks',default=0)
     generaterst_parser.add_argument('--nblink',type=str,help='where to place notebook links',choices=['bottom', 'top', 'both', 'none'], default='bottom')
     generaterst_parser.add_argument('--skip',type=str,help='notebooks to skip running; comma separated case insensitive re to match',default='')
+    generaterst_parser.add_argument('--strip-numbers',action='store_true',help='whether to strip the leading numbers off of notebook URLs and titles')
     _set_defaults(generaterst_parser,generate_rst)
 
     build_parser = subparsers.add_parser("build", help=inspect.getdoc(build))

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -101,7 +101,8 @@ def generate_rst(
         offset=0,
         overwrite=False,
         nblink='bottom',
-        skip=''):
+        skip='',
+        strip_numbers=False):
     """Auto-generates notebook-including rsts from notebooks in examples.
 
     titles
@@ -164,14 +165,14 @@ def generate_rst(
 
     print("Project='%s': Converting notebooks at '%s' to rst at '%s'..."%(project_name,paths['examples'],paths['doc']))
     for filename in glob.iglob(os.path.join(paths['examples'],"**","*.ipynb"), recursive=True):
-        fromhere = filename.split(paths['examples'])[1].lstrip('/') # TODO: not win
+        relpath = os.path.relpath(filename, paths['examples'])
         # TODO: decide what to do about gallery later
-        if fromhere.startswith('gallery'):
+        if relpath.startswith('gallery'):
             continue
-        if _should_skip(skip, fromhere):
-            print('...deliberately skipping', fromhere)
+        if _should_skip(skip, relpath):
+            print('...deliberately skipping', relpath)
             continue
-        rst = os.path.splitext(os.path.join(paths['doc'],fromhere))[0] + ".rst"
+        rst = os.path.splitext(os.path.join(paths['doc'], relpath))[0] + ".rst"
         pretitle = _file2pretitle(rst)
         os.makedirs(dirname(rst), exist_ok=True)
 
@@ -198,22 +199,22 @@ def generate_rst(
             rst_file.write('*'*len(title)+'\n\n')
 
             if nblink in ['top', 'both']:
-                add_nblink(rst_file, host,org,repo, branch, examples, fromhere)
+                add_nblink(rst_file, host, org, repo, branch, examples, relpath)
                 rst_file.write('\n\n-------\n\n')
 
-            rst_file.write(".. notebook:: %s %s" % (project_name,os.path.relpath(paths['examples'],start=dirname(rst))+'/'+fromhere+"\n"))
+            rst_file.write(".. notebook:: %s %s" % (project_name,os.path.relpath(paths['examples'],start=dirname(rst))+'/'+relpath+"\n"))
             rst_file.write("    :offset: %s\n" % offset)
 
             if pretitle=='index':
-                rst_file.write("%s\n"%_toctree(dirname(filename),paths['examples']))
+                rst_file.write("%s\n"%_toctree(dirname(filename), paths['examples']))
             if nblink in ['bottom', 'both']:
                 rst_file.write('\n\n-------\n\n')
-                add_nblink(rst_file, host,org,repo, branch, examples, fromhere)
+                add_nblink(rst_file, host, org, repo, branch, examples, relpath)
 
 
-def add_nblink(rst_file, host,org,repo,branch,examples, fromhere):
-    if all([host,org,repo,branch]):
-        info = (hosts[host],org,repo,branch,examples,fromhere)
+def add_nblink(rst_file, host, org, repo, branch, examples, relpath):
+    if all([host, org, repo, branch]):
+        info = (hosts[host], org, repo, branch, examples,relpath)
         rst_file.write('`Right click to download this notebook from ' + host + '.'
                        ' <%s/%s/%s/%s/%s/%s>`_\n' % info)
 

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -8,6 +8,15 @@ from collections import ChainMap
 
 from .util import copy_files
 
+DEFAULT_PYVIZ_ORDERING = [
+    "Introduction",
+    "Getting Started",
+    "User Guide",
+    "Topics",
+    "FAQ",
+    "API"
+]
+
 def init(project_root='',doc='doc'):
     """Start an nbsite project: create a doc folder containing nbsite
 template files
@@ -115,6 +124,7 @@ def generate_rst(
       * 01_The_Title.ipynb -> 01 The Title
       * 01_Hyphen-Conscious_Title.ipynb -> 01 Hyphen-Conscious Title
       * 1_some_title.ipynb -> 1 Some Title
+      * 1_stripped_title.ipynb -> Stripped Title  # with ``strip_numbers`` flag
 
     But: index.ipynb gets title from its containing directory in
     general, except at the root, where index.ipynb gets the
@@ -131,7 +141,7 @@ def generate_rst(
         number
 
       * after dealing with numeric prefixes, items in
-        default_pyviz_ordering ("Introduction","Getting Started","User
+        DEFAULT_PYVIZ_ORDERING ("Introduction","Getting Started","User
         Guide","Topics","FAQ","API") grouped next, sorted in that
         order
 
@@ -150,6 +160,8 @@ def generate_rst(
 
       * offset: allows to skip leading n cells
       * overwrite: will overwrite existing rst files [DANGEROUS]
+      * strip_numbers: strips off leading numbers from title and path, but
+        maintains ordering in toc
       * ...
 
     """
@@ -173,6 +185,7 @@ def generate_rst(
             print('...deliberately skipping', relpath)
             continue
         rst = os.path.splitext(os.path.join(paths['doc'], relpath))[0] + ".rst"
+        rst = _path_and_order(rst, strip_numbers)[0]
         pretitle = _file2pretitle(rst)
         os.makedirs(dirname(rst), exist_ok=True)
 
@@ -183,7 +196,7 @@ def generate_rst(
                 title = project_name
             else:
                 title = _filepath2pretitle(rst,paths['doc'])
-            title = _to_title(title,apply_title_case=True)
+            title = _to_title(title, apply_title_case=True)
 
         if os.path.exists(rst):
             if not overwrite:
@@ -206,7 +219,7 @@ def generate_rst(
             rst_file.write("    :offset: %s\n" % offset)
 
             if pretitle=='index':
-                rst_file.write("%s\n"%_toctree(dirname(filename), paths['examples']))
+                rst_file.write("%s\n"%_toctree(dirname(filename), paths['examples'], strip_numbers))
             if nblink in ['bottom', 'both']:
                 rst_file.write('\n\n-------\n\n')
                 add_nblink(rst_file, host, org, repo, branch, examples, relpath)
@@ -237,31 +250,46 @@ def _filepath2pretitle(filepath,root):
 def _file2pretitle(file_):
     return os.path.splitext(os.path.basename(file_))[0]
 
-default_pyviz_ordering = ["Introduction","Getting Started","User Guide","Topics","FAQ","API"]
-def _title_key(title):
-    leading_digits = re.match(r"\d+",title)
-    return (0,int(leading_digits.group(0)),title) if leading_digits else (1,default_pyviz_ordering.index(title) if title in default_pyviz_ordering else float("inf"),title)
+def _title_key(title_tup):
+    title, order = title_tup[0], title_tup[1]['order']
+    if order is not None:
+        return (0, order, title)
+    elif title in DEFAULT_PYVIZ_ORDERING:
+        return (1, DEFAULT_PYVIZ_ORDERING.index(title), title)
+    else:
+        return (1, float("inf"), title)
 
-def _toctree(nbpath,examples_path):
-    #
-    # rst:
-    # ipynb:
-    # dir: dir containing index.ipynb
+def _path_and_order(filepath, strip_numbers):
+    num_name = os.path.basename(filepath)
+    leading_num = re.match(r"\d+", num_name)
+    if strip_numbers:
+        name = re.split(r"\d( |-|_)", num_name)[-1]
+        filepath = filepath.replace(num_name, name)
+    return filepath, int(leading_num.group(0)) if leading_num else None
 
-    tocmap = {}
+def _toctree(nbpath, examples_path, strip_numbers):
+    tocmap = {'ipynb': {},'rst': {}}
     for ftype in ('ipynb','rst'):
-        tocmap[ftype] = {_to_title(k):"<%s>"%k for k in [_file2pretitle(f) for f in glob.iglob(os.path.join(nbpath,'*.'+ftype), recursive=False)]}
+        for f in glob.iglob(os.path.join(nbpath,'*.'+ftype), recursive=False):
+            f, order = _path_and_order(f, strip_numbers)
+            k = _file2pretitle(f)
+            tocmap[ftype][_to_title(k)] = {'path': "<%s>"%k, 'order': order}
 
-    tocmap['dir'] = {_to_title(k,apply_title_case=True):"<%s/index>"%k for k in [_filepath2pretitle(x,examples_path) for x in glob.glob(os.path.join(nbpath,"**","index.ipynb"))]}
+    tocmap['dir'] = {
+        _to_title(k, apply_title_case=True): {'path': "<%s/index>"%k, 'order': None} for k in [
+            _filepath2pretitle(x, examples_path) for x in glob.glob(os.path.join(nbpath, "**", "index.ipynb"))]}
 
     # index shouldn't explicitly appear in toctree...
     if 'index' in tocmap['rst'] or 'index' in tocmap['ipynb']:
-        tocmap['rst'].pop('index',None)
-        tocmap['ipynb'].pop('index',None)
+        tocmap['rst'].pop('index', None)
+        tocmap['ipynb'].pop('index', None)
     # ...except at root (where it gets called Introduction)
     if _is_root(nbpath,examples_path):
-        assert not any(['Introduction' in tocmap[x] for x in tocmap]), "index will be shown as Introduction, but Introduction already exists in %s"%examples_path
-        tocmap['rst']['Introduction'] ='<self>'
+        if any(['Introduction' in tocmap[x] for x in tocmap]):
+            raise ValueError("index will be shown as Introduction, but Introduction "
+                             "already exists in %s" % examples_path)
+
+        tocmap['rst']['Introduction'] = {'path': '<self>', 'order': -1}
 
     titles = ChainMap(*[tocmap[x] for x in tocmap])
 
@@ -270,8 +298,8 @@ def _toctree(nbpath,examples_path):
     :titlesonly:
     :maxdepth: 2
 """
-    for title in sorted(titles,key=_title_key):
+    for title, title_dict in sorted(titles.items(), key=_title_key):
         toctree += """
-    %s %s"""%(title,titles[title])
+    %s %s"""%(title, title_dict['path'])
 
     return toctree

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -261,9 +261,9 @@ def _title_key(title_tup):
 
 def _path_and_order(filepath, strip_numbers):
     num_name = os.path.basename(filepath)
-    leading_num = re.match(r"\d+", num_name)
+    leading_num = re.match(r"^\d+", num_name)
     if strip_numbers:
-        name = re.split(r"\d( |-|_)", num_name)[-1]
+        name = re.split(r"^\d+( |-|_)", num_name)[-1]
         filepath = filepath.replace(num_name, name)
     return filepath, int(leading_num.group(0)) if leading_num else None
 

--- a/nbsite/tests/test_cmd.py
+++ b/nbsite/tests/test_cmd.py
@@ -133,35 +133,35 @@ Project
    :hidden:
    :maxdepth: 2
 
-   Example_0 <Example_Notebook_0>
-   Example_1 <Example_Notebook_1>
-   Example_2 <Example_Notebook_2>
+   0 <0_Zeroth_Notebook>
+   1 <1_First_Notebook>
+   2 <2_Second_Notebook>
 """
 
 EXAMPLE_0_RST = u"""
 ******************
-Example Notebook 0
+0 Zeroth Notebook
 ******************
 
-.. notebook:: test_project ../examples/Example_Notebook_0.ipynb
+.. notebook:: test_project ../examples/0_Zeroth_Notebook.ipynb
     :offset: 0
 """
 
 EXAMPLE_1_RST = u"""
 ******************
-Example Notebook 1
+1 First Notebook
 ******************
 
-.. notebook:: test_project ../examples/Example_Notebook_1.ipynb
+.. notebook:: test_project ../examples/1_First_Notebook.ipynb
     :offset: 0
 """
 
 EXAMPLE_2_RST = u"""
 ******************
-Example Notebook 2
+2 Second Notebook
 ******************
 
-.. notebook:: test_project ../examples/Example_Notebook_2.ipynb
+.. notebook:: test_project ../examples/2_Second_Notebook.ipynb
     :offset: 0
 """
 
@@ -172,9 +172,9 @@ def tmp_module(tmp_path):
     project = tmp_path / "static_module"
     project.mkdir()
     (project / "examples").mkdir()
-    (project / "examples" / "Example_Notebook_0.ipynb").write_text(EXAMPLE_0_CONTENT)
-    (project / "examples" / "Example_Notebook_1.ipynb").write_text(EXAMPLE_1_CONTENT)
-    (project / "examples" / "Example_Notebook_2.ipynb").write_text(EXAMPLE_2_CONTENT)
+    (project / "examples" / "0_Zeroth_Notebook.ipynb").write_text(EXAMPLE_0_CONTENT)
+    (project / "examples" / "1_First_Notebook.ipynb").write_text(EXAMPLE_1_CONTENT)
+    (project / "examples" / "2_Second_Notebook.ipynb").write_text(EXAMPLE_2_CONTENT)
     (project / "examples" / "data").mkdir()
     (project / "examples" / "data" / "data_0.csv").write_text(DATA_FILE_0_CONTENT)
     (project / "examples" / "data" / "data_1.csv").write_text(DATA_FILE_1_CONTENT)
@@ -214,45 +214,62 @@ def tmp_project_with_docs_skeleton(tmp_project):
 
 def test_generate_rst(tmp_project):
     project = tmp_project
+
     generate_rst("test_project", project_root=str(project))
-    assert (project / "doc" / "Example_Notebook_0.rst").is_file()
-    assert (project / "doc" / "Example_Notebook_1.rst").is_file()
+    assert (project / "doc" / "0_Zeroth_Notebook.rst").is_file()
+    assert (project / "doc" / "1_First_Notebook.rst").is_file()
 
 def test_generate_rst_with_skip_one_notebook(tmp_project):
     project = tmp_project
-    generate_rst("test_project", project_root=str(project), skip='.*Notebook_0.*')
-    assert not (project / "doc" / "Example_Notebook_0.rst").is_file()
-    assert (project / "doc" / "Example_Notebook_1.rst").is_file()
+    generate_rst("test_project", project_root=str(project), skip='.*0_.*')
+    assert not (project / "doc" / "0_Zeroth_Notebook.rst").is_file()
+    assert (project / "doc" / "1_First_Notebook.rst").is_file()
 
 def test_generate_rst_with_skip_list_of_notebooks(tmp_project):
     project = tmp_project
-    generate_rst("test_project", project_root=str(project), skip='.*Notebook_0.*, .*Notebook_1.*')
-    assert not (project / "doc" / "Example_Notebook_0.rst").is_file()
-    assert not (project / "doc" / "Example_Notebook_1.rst").is_file()
+    generate_rst("test_project", project_root=str(project), skip='.*0_.*, .*1_.*')
+    assert not (project / "doc" / "0_Zeroth_Notebook.rst").is_file()
+    assert not (project / "doc" / "1_First_Notebook.rst").is_file()
 
 def test_generate_rst_with_skip_glob_matching_both_notebooks(tmp_project):
     project = tmp_project
-    generate_rst("test_project", project_root=str(project), skip='.*Example.*')
-    assert not (project / "doc" / "Example_Notebook_0.rst").is_file()
-    assert not (project / "doc" / "Example_Notebook_1.rst").is_file()
+    generate_rst("test_project", project_root=str(project), skip='.*Notebook.*')
+    assert not (project / "doc" / "0_Zeroth_Notebook.rst").is_file()
+    assert not (project / "doc" / "1_First_Notebook.rst").is_file()
 
 def test_generate_rst_with_skip_glob_matching_both_notebooks_undercase(tmp_project):
     project = tmp_project
-    generate_rst("test_project", project_root=str(project), skip='.*example.*')
-    assert not (project / "doc" / "Example_Notebook_0.rst").is_file()
-    assert not (project / "doc" / "Example_Notebook_1.rst").is_file()
+    generate_rst("test_project", project_root=str(project), skip='.*notebook.*')
+    assert not (project / "doc" / "0_Zeroth_Notebook.rst").is_file()
+    assert not (project / "doc" / "1_First_Notebook.rst").is_file()
+
+
+def test_generate_rst_with_numbers_stripped(tmp_project):
+
+    expected_index_toc = (
+        '    Zeroth Notebook <Zeroth_Notebook>\n'
+        '    First Notebook <First_Notebook>\n'
+        '    Second Notebook <Second_Notebook>')
+
+    project = tmp_project
+    (project / "examples" / "index.ipynb").write_text(EXAMPLE_0_CONTENT)
+    generate_rst("test_project", project_root=str(project), strip_numbers=True)
+    assert (project / "doc" / "index.rst").is_file()
+    assert expected_index_toc in (project / "doc" / "index.rst").read_text()
+    assert (project / "doc" / "Zeroth_Notebook.rst").is_file()
+    assert (project / "doc" / "First_Notebook.rst").is_file()
 
 def test_generate_rst_with_nblink_as_none(tmp_project):
 
-    expected = ['******************',
-                'Example Notebook 1',
-                '******************',
-                '', '.. notebook:: test_project ../examples/Example_Notebook_1.ipynb',
+    expected = ['****************',
+                '1 First Notebook',
+                '****************',
+                '', '.. notebook:: test_project ../examples/1_First_Notebook.ipynb',
                 '    :offset: 0']
     project = tmp_project
     generate_rst("test_project", project_root=str(project), nblink='none',
                  host='GitHub', org='pyviz', repo='nbsite', branch='master')
-    rstpath = (project / "doc" / "Example_Notebook_1.rst")
+    rstpath = (project / "doc" / "1_First_Notebook.rst")
     assert rstpath.is_file()
     with open(rstpath, 'r') as f:
         contents = f.read().splitlines()
@@ -260,19 +277,19 @@ def test_generate_rst_with_nblink_as_none(tmp_project):
 
 def test_generate_rst_with_nblink_top(tmp_project):
 
-    expected = ['******************',
-                'Example Notebook 1',
-                '******************',
+    expected = ['****************',
+                '1 First Notebook',
+                '****************',
                 '',
-                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/Example_Notebook_1.ipynb>`_',
+                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/1_First_Notebook.ipynb>`_',
                 '', '', '-------', '',
-                '.. notebook:: test_project ../examples/Example_Notebook_1.ipynb',
+                '.. notebook:: test_project ../examples/1_First_Notebook.ipynb',
                 '    :offset: 0']
 
     project = tmp_project
     generate_rst("test_project", project_root=str(project), nblink='top',
                  host='GitHub', org='pyviz', repo='nbsite', branch='master')
-    rstpath = (project / "doc" / "Example_Notebook_1.rst")
+    rstpath = (project / "doc" / "1_First_Notebook.rst")
     assert rstpath.is_file()
     with open(rstpath, 'r') as f:
         contents = f.read().splitlines()
@@ -280,21 +297,21 @@ def test_generate_rst_with_nblink_top(tmp_project):
 
 def test_generate_rst_with_nblink_both(tmp_project):
 
-    expected = ['******************',
-                'Example Notebook 1',
-                '******************',
+    expected = ['****************',
+                '1 First Notebook',
+                '****************',
                 '',
-                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/Example_Notebook_1.ipynb>`_',
+                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/1_First_Notebook.ipynb>`_',
                 '', '', '-------', '',
-                '.. notebook:: test_project ../examples/Example_Notebook_1.ipynb',
+                '.. notebook:: test_project ../examples/1_First_Notebook.ipynb',
                 '    :offset: 0',
                 '', '', '-------', '',
-                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/Example_Notebook_1.ipynb>`_']
+                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/1_First_Notebook.ipynb>`_']
 
     project = tmp_project
     generate_rst("test_project", project_root=str(project), nblink='both',
                  host='GitHub', org='pyviz', repo='nbsite', branch='master')
-    rstpath = (project / "doc" / "Example_Notebook_1.rst")
+    rstpath = (project / "doc" / "1_First_Notebook.rst")
     assert rstpath.is_file()
     with open(rstpath, 'r') as f:
         contents = f.read().splitlines()
@@ -302,38 +319,38 @@ def test_generate_rst_with_nblink_both(tmp_project):
 
 def test_generate_rst_with_nblink_bottom(tmp_project):
 
-    expected = ['******************',
-                'Example Notebook 1',
-                '******************',
+    expected = ['****************',
+                '1 First Notebook',
+                '****************',
                 '',
-                '.. notebook:: test_project ../examples/Example_Notebook_1.ipynb',
+                '.. notebook:: test_project ../examples/1_First_Notebook.ipynb',
                 '    :offset: 0',
                 '', '', '-------', '',
-                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/Example_Notebook_1.ipynb>`_']
+                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/1_First_Notebook.ipynb>`_']
 
     project = tmp_project
     generate_rst("test_project", project_root=str(project), nblink='bottom',
                  host='GitHub', org='pyviz', repo='nbsite', branch='master')
-    rstpath = (project / "doc" / "Example_Notebook_1.rst")
+    rstpath = (project / "doc" / "1_First_Notebook.rst")
     assert rstpath.is_file()
     with open(rstpath, 'r') as f:
         contents = f.read().splitlines()
         assert  contents[5:] == expected
 
 def test_generate_rst_with_no_nblink_set_defaults_to_bottom(tmp_project):
-    expected = ['******************',
-                'Example Notebook 1',
-                '******************',
+    expected = ['****************',
+                '1 First Notebook',
+                '****************',
                 '',
-                '.. notebook:: test_project ../examples/Example_Notebook_1.ipynb',
+                '.. notebook:: test_project ../examples/1_First_Notebook.ipynb',
                 '    :offset: 0',
                 '', '', '-------', '',
-                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/Example_Notebook_1.ipynb>`_']
+                '`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/nbsite/master/examples/1_First_Notebook.ipynb>`_']
 
     project = tmp_project
     generate_rst("test_project", project_root=str(project),
                  host='GitHub', org='pyviz', repo='nbsite', branch='master')
-    rstpath = (project / "doc" / "Example_Notebook_1.rst")
+    rstpath = (project / "doc" / "1_First_Notebook.rst")
     assert rstpath.is_file()
     with open(rstpath, 'r') as f:
         contents = f.read().splitlines()
@@ -343,60 +360,60 @@ def test_generate_rst_with_no_nblink_set_defaults_to_bottom(tmp_project):
 @pytest.mark.slow
 def test_build(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
-    (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
+    (project / "doc" / "0_Zeroth_Notebook.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "1_First_Notebook.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
-    assert (project / "doc" / "Example_Notebook_0.ipynb").is_file()
-    assert (project / "doc" / "Example_Notebook_1.ipynb").is_file()
-    assert (project / "builtdocs" / "Example_Notebook_0.html").is_file()
-    assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
+    assert (project / "doc" / "0_Zeroth_Notebook.ipynb").is_file()
+    assert (project / "doc" / "1_First_Notebook.ipynb").is_file()
+    assert (project / "builtdocs" / "0_Zeroth_Notebook.html").is_file()
+    assert (project / "builtdocs" / "1_First_Notebook.html").is_file()
 
 @pytest.mark.slow
 def test_build_with_nblink_at_top_succeeds(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
     generate_rst("test_project", project_root=str(project), nblink='top',
                  host='GitHub', org='pyviz', repo='nbsite', branch='master')
-    rstpath = (project / "doc" / "Example_Notebook_1.rst")
+    rstpath = (project / "doc" / "1_First_Notebook.rst")
     assert rstpath.is_file()
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
-    assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
-    html = (project / "builtdocs" / "Example_Notebook_1.html").read_text()
+    assert (project / "builtdocs" / "1_First_Notebook.html").is_file()
+    html = (project / "builtdocs" / "1_First_Notebook.html").read_text()
     assert 'This is another temporary notebook that gets created for tests' in html, \
            "The notebook did not get build to html properly - look for sphinx warnings and errors"
 
 @pytest.mark.slow
 def test_build_with_just_one_rst(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "0_Zeroth_Notebook.rst").write_text(EXAMPLE_0_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
-    assert (project / "builtdocs" / "Example_Notebook_0.html").is_file()
-    assert not (project / "builtdocs" / "Example_Notebook_1.html").is_file()
+    assert (project / "builtdocs" / "0_Zeroth_Notebook.html").is_file()
+    assert not (project / "builtdocs" / "1_First_Notebook.html").is_file()
     assert (project / "builtdocs" / ".nojekyll").is_file()
 
 @pytest.mark.slow
 def test_build_deletes_by_default(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
-    (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
+    (project / "doc" / "0_Zeroth_Notebook.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "1_First_Notebook.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
     assert not (project / "builtdocs" / ".doctrees").is_dir()
-    assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
+    assert (project / "builtdocs" / "1_First_Notebook.html").is_file()
     assert len(list((project / "builtdocs").iterdir())) == 9
 
 @pytest.mark.slow
 def test_build_with_clean_dry_run_does_not_delete(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
-    (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
+    (project / "doc" / "0_Zeroth_Notebook.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "1_First_Notebook.rst").write_text(EXAMPLE_1_RST)
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='', clean_dry_run=True)
     assert (project / "builtdocs" / ".doctrees").is_dir()
-    assert (project / "builtdocs" / "Example_Notebook_1.html").is_file()
+    assert (project / "builtdocs" / "1_First_Notebook.html").is_file()
     assert len(list((project / "builtdocs").iterdir())) == 12
 
 @pytest.mark.slow
 def test_build_copies_json(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "0_Zeroth_Notebook.rst").write_text(EXAMPLE_0_RST)
     (project / "doc" / "example_json_blob.json").write_text("some json")
     (project / "doc" / "topics").mkdir()
     (project / "doc" / "topics" / "nested_example_json_blob.json").write_text("some json")
@@ -408,13 +425,13 @@ def test_build_copies_json(tmp_project_with_docs_skeleton):
 @pytest.mark.slow
 def test_build_with_error_output(tmp_project_with_docs_skeleton):
     project = tmp_project_with_docs_skeleton
-    (project / "doc" / "Example_Notebook_0.rst").write_text(EXAMPLE_0_RST)
-    (project / "doc" / "Example_Notebook_1.rst").write_text(EXAMPLE_1_RST)
-    (project / "doc" / "Example_Notebook_2.rst").write_text(EXAMPLE_2_RST)
-    assert not (project / "doc" / "Example_Notebook_2.ipynb").is_file()
+    (project / "doc" / "0_Zeroth_Notebook.rst").write_text(EXAMPLE_0_RST)
+    (project / "doc" / "1_First_Notebook.rst").write_text(EXAMPLE_1_RST)
+    (project / "doc" / "2_Second_Notebook.rst").write_text(EXAMPLE_2_RST)
+    assert not (project / "doc" / "2_Second_Notebook.ipynb").is_file()
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
-    assert (project / "doc" / "Example_Notebook_1.ipynb").is_file()
-    assert (project / "doc" / "Example_Notebook_2.ipynb").is_file()
-    nb = json.loads((project / "doc" / "Example_Notebook_2.ipynb").read_text())
+    assert (project / "doc" / "1_First_Notebook.ipynb").is_file()
+    assert (project / "doc" / "2_Second_Notebook.ipynb").is_file()
+    nb = json.loads((project / "doc" / "2_Second_Notebook.ipynb").read_text())
     assert nb['cells'][1]['outputs'][0]['ename'] == 'ModuleNotFoundError'
     assert len(nb['cells'][2]['outputs']) == 0

--- a/nbsite/tests/test_cmd.py
+++ b/nbsite/tests/test_cmd.py
@@ -58,6 +58,13 @@ EXAMPLE_1_CONTENT = u"""{
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is a ref to the [other notebook](0_Zeroth_Notebook.ipynb)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -247,6 +254,7 @@ def test_generate_rst_with_skip_glob_matching_both_notebooks_undercase(tmp_proje
 def test_generate_rst_with_numbers_stripped(tmp_project):
 
     expected_index_toc = (
+        '    Introduction <self>\n'
         '    Zeroth Notebook <Zeroth_Notebook>\n'
         '    First Notebook <First_Notebook>\n'
         '    Second Notebook <Second_Notebook>')
@@ -435,3 +443,16 @@ def test_build_with_error_output(tmp_project_with_docs_skeleton):
     nb = json.loads((project / "doc" / "2_Second_Notebook.ipynb").read_text())
     assert nb['cells'][1]['outputs'][0]['ename'] == 'ModuleNotFoundError'
     assert len(nb['cells'][2]['outputs']) == 0
+
+@pytest.mark.slow
+def test_build_with_numbers_stripped(tmp_project):
+    project = tmp_project
+    (project / "doc").mkdir()
+    (project / "doc" / "conf.py").write_text(CONF_CONTENT)
+    (project / "examples" / "index.ipynb").write_text(EXAMPLE_0_CONTENT)
+    generate_rst("test_project", project_root=str(project), strip_numbers=True)
+    build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
+    assert (project / "doc" / "1_First_Notebook.ipynb").is_file()
+    assert (project / "builtdocs" / "First_Notebook.html").is_file()
+    html = (project / "builtdocs" / "First_Notebook.html").read_text()
+    assert '<a href="Zeroth_Notebook.html">other notebook</a>' in html

--- a/scripts/nbsite_fix_links.py
+++ b/scripts/nbsite_fix_links.py
@@ -6,6 +6,7 @@ extension.
 import os
 import re
 from bs4 import BeautifulSoup
+import warnings
 
 
 # TODO: holoviews specific links e.g. to reference manual...doc & generalize
@@ -117,9 +118,9 @@ def cleanup_links(path, inspect_links=False):
                     if os.path.exists(new_path):
                         a['href'] = os.path.relpath(new_path, os.path.dirname(path))
                     else:
-                        raise ValueError('Cannot find html to link to. Original href: {}, '
-                                         'first tried: {}, then tried: {}'.format(
-                                         a['href'], try_path, new_path))
+                        warnings.warn('Cannot find html to link to. Original href: {}, '
+                                      'first tried: {}, then tried: {}'.format(
+                                       a['href'], try_path, new_path), )
 
         if inspect_links and 'http' in a['href']:
             print(a['href'])

--- a/scripts/nbsite_fix_links.py
+++ b/scripts/nbsite_fix_links.py
@@ -112,7 +112,7 @@ def cleanup_links(path, inspect_links=False):
                 try_path = os.path.join(os.path.dirname(path), a['href'])
                 if not os.path.exists(try_path):
                     num_name = os.path.basename(try_path)
-                    name = re.split(r"\d( |-|_)", num_name)[-1]
+                    name = re.split(r"^\d+( |-|_)", num_name)[-1]
                     new_path = try_path.replace(num_name, name)
                     if os.path.exists(new_path):
                         a['href'] = os.path.relpath(new_path, os.path.dirname(path))

--- a/scripts/nbsite_fix_links.py
+++ b/scripts/nbsite_fix_links.py
@@ -107,6 +107,20 @@ def cleanup_links(path, inspect_links=False):
                 a['href'] = '/'.join(parts[:-1]+[parts[-1][2:-5]+'html'])
             else:
                 a['href'] = href.replace('.ipynb', '.html')
+
+                # check to make sure that path exists, if not, try un-numbered version
+                try_path = os.path.join(os.path.dirname(path), a['href'])
+                if not os.path.exists(try_path):
+                    num_name = os.path.basename(try_path)
+                    name = re.split(r"\d( |-|_)", num_name)[-1]
+                    new_path = try_path.replace(num_name, name)
+                    if os.path.exists(new_path):
+                        a['href'] = os.path.relpath(new_path, os.path.dirname(path))
+                    else:
+                        raise ValueError('Cannot find html to link to. Original href: {}, '
+                                         'first tried: {}, then tried: {}'.format(
+                                         a['href'], try_path, new_path))
+
         if inspect_links and 'http' in a['href']:
             print(a['href'])
     with open(path, 'w') as f:


### PR DESCRIPTION
Closes #115 

This PR allows you to pass `--strip-numbers` to `nbsite generate_rst`. This flag strips the numbers off any notebooks while maintaining ordering. This PR also checks relative links, strips the number if it can't find the html file, or otherwise warn if the file isn't there.