### PR TITLE
Improved formatting of parameters in reference docs

### DIFF
--- a/nbsite/paramdoc.py
+++ b/nbsite/paramdoc.py
@@ -5,6 +5,14 @@ import param
 param.parameterized.docstring_signature = False
 param.parameterized.docstring_describe_params = False
 
+# Parameter attributes which are never shown
+IGNORED_ATTRS = [
+    'precedence', 'check_on_set', 'instantiate', 'pickle_default_value',
+    'watchers', 'compute_default_fn']
+
+# Default parameter attribute values (value not shown if it matches defaults)
+DEFAULT_VALUES = {'allow_None': False, 'readonly': False}
+
 
 def param_formatter(app, what, name, obj, options, lines):
     if what == 'module':
@@ -16,17 +24,13 @@ def param_formatter(app, what, name, obj, options, lines):
             if child in ["print_level", "name"]:
                 continue
             pobj = params[child]
-            try:
-                default = type(pobj)()
-            except:
-                default = None
             doc = pobj.doc or ""
             members = inspect.getmembers(pobj)
             params_str = ""
             for m in members:
-                if (m[0][0] != "_" and m[0] in ("default", "bounds", "objects", "length", "step") and
-                    not inspect.ismethod(m[1]) and not inspect.isfunction(m[1]) and m[1] is not None and
-                    getattr(default, m[0], None) != m[1]):
+                if (m[0][0] != "_" and m[0] not in IGNORED_ATTRS and
+                    not inspect.ismethod(m[1]) and not inspect.isfunction(m[1]) and
+                    m[1] is not None and DEFAULT_VALUES.get(m[0]) != m[1]):
                     params_str += "%s=%s, " % (m[0], repr(m[1]))
             params_str = params_str[:-2]
             ptype = params[child].__class__.__name__


### PR DESCRIPTION
The current formatting for parameters in Sphinx API reference documentation is downright terrible, e.g. see:

<img width="1125" alt="Screen Shot 2019-05-31 at 3 21 30 PM" src="https://user-images.githubusercontent.com/1550771/58708349-d5c19c00-83b7-11e9-9193-e91c314c8a96.png">

Most of the attributes are either something no one really cares about OR it displays the default values which definitely no one cares about. This is an attempt to improve the formatting a bit and remove useless information. Admittedly this is a different theme so ignore the styling but the content is much more relevant using this new scheme:

<img width="454" alt="Screen Shot 2019-05-31 at 3 23 09 PM" src="https://user-images.githubusercontent.com/1550771/58708479-39e46000-83b8-11e9-939b-436722b09b91.png">

One of the main issues is that this hardcodes the parameter attributes someone might care about, which won't work for user defined parameters which might have additional attributes.