### PR TITLE
Strip time magic when making gallery

### DIFF
--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -408,7 +408,7 @@ def generate_gallery(app, page):
                     pass
                 elif extension == 'ipynb':
                     verb = 'Successfully generated'
-                    code = notebook_thumbnail(f, os.path.join(*(['doc']+path_components)))
+                    code = notebook_thumbnail(f, dest_dir)
                     code = script_prefix + code
                     my_env = os.environ.copy()
                     retcode = execute(code.encode('utf8'), env=my_env, cwd=os.path.split(f)[0])


### PR DESCRIPTION
There are lots of examples in pyviz-topics that use `%time` and `%%time`. These magics can just be stripped when generating thumbnails.

I was getting errors like:

```python
Traceback (most recent call last):
  File "<stdin>", line 79, in <module>
NameError: name 'get_ipython' is not defined
```