### PR TITLE
Reduce thumbnail url when . in path

### DIFF
--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -406,7 +406,9 @@ def generate_gallery(app, page):
                 if backend:
                     url_components.append(backend)
                 url_components.append('%s.png' % basename)
-                thumb_url = '/'.join(url_components)
+
+                # if there is a . in the path, just get rid of it
+                thumb_url = '/'.join(url_components).replace('/./', '/')
 
                 thumb_dir = os.path.join(dest_dir, 'thumbnails')
                 if not os.path.isdir(thumb_dir):


### PR DESCRIPTION
This makes https://github.com/pyviz-topics/examples/blob/8f84a93e02dee1713803208f25d62bbd9afcda64/doc/conf.py#L65 work despite the gallery being top level. 